### PR TITLE
added simple error message for no followers to text

### DIFF
--- a/src/main/java/com/libertymutual/goforcode/localhope/controllers/MessageController.java
+++ b/src/main/java/com/libertymutual/goforcode/localhope/controllers/MessageController.java
@@ -46,6 +46,10 @@ public class MessageController {
 		
 		ArrayList <UserD> followers = charity.listFollowers(userRepository);
 		
+		if(followers.get(0) == null) {
+		return "You can't send any messages because you don't have any followers.  How sad.  :(";
+		}
+		
 		for(int i = 0; i < followers.size(); i++) {
 		  	UserD follower = followers.get(i);
 		  	String phone = follower.getPhone();


### PR DESCRIPTION
Now returns a message when you try to send a message for a charity with zero followers.