### PR TITLE
added hasFollowers to need

### DIFF
--- a/src/main/java/com/libertymutual/goforcode/localhope/configuration/SeedData.java
+++ b/src/main/java/com/libertymutual/goforcode/localhope/configuration/SeedData.java
@@ -71,9 +71,9 @@ public class SeedData {
         java.util.Date utilDate = new java.util.Date();
         java.sql.Date sqlDate = new java.sql.Date(utilDate.getTime());
         
-		needRepository.save(new Need(1L, "crib",  false, "We need those cribs!", 10, "units", sqlDate, users));
-		needRepository.save(new Need(2L, "money", false, "We need to buy more cribs.", 200, "units", sqlDate, users));
-		needRepository.save(new Need(3L, "volunteer", false, "We need to deliver them cribs.", 6, "units", sqlDate, users));
+		needRepository.save(new Need(1L, "crib",  false, "We need those cribs!", 10, "units", sqlDate, users, false));
+		needRepository.save(new Need(2L, "money", false, "We need to buy more cribs.", 200, "units", sqlDate, users, false));
+		needRepository.save(new Need(3L, "volunteer", false, "We need to deliver them cribs.", 6, "units", sqlDate, users, false));
 		
 				
 		userRepository.save(new UserD(31L, 

--- a/src/main/java/com/libertymutual/goforcode/localhope/controllers/CharityController.java
+++ b/src/main/java/com/libertymutual/goforcode/localhope/controllers/CharityController.java
@@ -1,5 +1,7 @@
 package com.libertymutual.goforcode.localhope.controllers;
 
+import static org.mockito.Matchers.intThat;
+
 import java.util.List;
 
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -32,6 +34,18 @@ public class CharityController {
 	@GetMapping("charity/{userid}")
 	public List<Need> addCharityNeed(@PathVariable long userid) {
 		UserD user = userRepository.findOne(userid);
+		List<Need> needs = user.getNeeds();
+		int sizeFollowers = user.getFollowers().length();
+		if (sizeFollowers == 0) {
+			for (int i = 0; i < needs.size(); i++) {
+				needs.get(i).setHasFollowers(false);
+			}
+		} else {
+			for (int i = 0; i < needs.size(); i++) {
+				needs.get(i).setHasFollowers(true);
+			}
+		}
+
 		return user.getNeeds();
 	}
 

--- a/src/main/java/com/libertymutual/goforcode/localhope/models/Need.java
+++ b/src/main/java/com/libertymutual/goforcode/localhope/models/Need.java
@@ -34,6 +34,8 @@ public class Need {
 	private String units;
 	
 	private Date dateNeeded;
+	
+	private Boolean hasFollowers;
 
 	
 	// Owner of the rel'p
@@ -44,7 +46,7 @@ public class Need {
 	public Need () {
 	}
 	
-	public Need(Long id, String type, Boolean needMet, String description, int originalAmount, String units, Date dateNeeded, List<UserD> users) {
+	public Need(Long id, String type, Boolean needMet, String description, int originalAmount, String units, Date dateNeeded, List<UserD> users, Boolean hasFollowers) {
 		//super();
 		this.id = id;
 		this.type = type;
@@ -54,6 +56,7 @@ public class Need {
 		this.units = units;
 		this.dateNeeded = dateNeeded;
 		this.users = users; 
+		this.hasFollowers = hasFollowers;
 	}
 
 	
@@ -123,5 +126,13 @@ public class Need {
 	}
 	public void setUnits(String units) {
 		this.units = units;
+	}
+
+	public Boolean getHasFollowers() {
+		return hasFollowers;
+	}
+
+	public void setHasFollowers(Boolean hasFollowers) {
+		this.hasFollowers = hasFollowers;
 	}
 }

--- a/src/main/java/com/libertymutual/goforcode/localhope/models/UserD.java
+++ b/src/main/java/com/libertymutual/goforcode/localhope/models/UserD.java
@@ -422,4 +422,12 @@ public class UserD implements UserDetails {
 		this.roles = roles;
 	}
 
+	public String getFollowers() {
+		return followers;
+	}
+
+	public void setFollowers(String followers) {
+		this.followers = followers;
+	}
+
 }


### PR DESCRIPTION
Added new field "hasFollowers" to Need model.  When returning a list of needs, hasFollowers boolean will check whether the associated charity has any followers and return "true" or "false" for each need.  This will allow the front-end to disable/hide the "send a text" button for charities with no followers rather than throwing an error.